### PR TITLE
[Feat] 트리거되는 job manifest명 구분

### DIFF
--- a/be18-specguard-backend/Jenkinsfile
+++ b/be18-specguard-backend/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
         PYTHON_IMAGE_NAME = 'viroovr/specguard-nlp'
         JAVA_DIR = 'be18-specguard-backend/backend'
         PYTHON_DIR = 'be18-specguard-backend/python-server'
-        
+
         DISCORD_WEBHOOK_CREDENTIALS_ID = 'specguard-backend-webhook'
         DOCKER_CREDENTIALS_ID = 'dockerhub-access'
     }
@@ -180,11 +180,12 @@ pipeline {
                 💡 **SpecGuard Backend CI/CD 알림**
                 🔹 Job : ${env.JOB_NAME}
                 🔹 Build : ${currentBuild.displayName}
+                🔹 Commit : ${env.GIT_COMMIT}
                 🔹 결과 : ${currentBuild.currentResult}
                 🔹 실행 시간 : ${currentBuild.duration / 1000}s
                 """,
                 result: currentBuild.currentResult,
-                title: "SpecGuard Pipeline : ${currentBuild.displayName}",
+                title: "SpecGuard BE Pipeline : ${env.GIT_COMMIT}",
                 webhookURL: "${DISCORD_WEBHOOK_URL}"
             }
         }

--- a/be18-specguard-frontend/Jenkinsfile
+++ b/be18-specguard-frontend/Jenkinsfile
@@ -123,11 +123,12 @@ pipeline {
                 💡 **SpecGuard Frontend CI/CD 알림**
                 🔹 Job : ${env.JOB_NAME}
                 🔹 Build : ${currentBuild.displayName}
+                🔹 Commit : ${env.GIT_COMMIT}
                 🔹 결과 : ${currentBuild.currentResult}
                 🔹 실행 시간 : ${currentBuild.duration / 1000}s
                 """,
                 result: currentBuild.currentResult,
-                title: "SpecGuard Pipeline : ${currentBuild.displayName}",
+                title: "SpecGuard FE Pipeline : ${env.GIT_COMMIT}",
                 webhookURL: "${DISCORD_WEBHOOK_URL}"
             }
 


### PR DESCRIPTION
<!-- 
제목 양식
[타입] 간단한 설명 (#이슈번호)
ex) [Feat] 게시글 생성 API 구현 (#23)

Feat	새로운 기능 추가
Fix	버그 수정
Refactor	코드 리팩토링
Style	스타일, 포맷 수정 (기능 변화 없음)
Chore	빌드, 설정, 패키지 등 기타 작업
Docs	문서 추가 또는 수정
Test	테스트 코드 추가/보완
-->

## 💡 작업 개요
<!-- 이번 PR에서 어떤 기능/버그를 다뤘는지 간단 요약 -->
- job manifest명을 FE, BE 구분해서 설정
- discord webhook url 두개 구분해서 설정
- docker image version에 commit sha 들어가도록 설정 : short 버전이라 앞 7글자


</br>

## 🔨 작업 내용
<!-- 어떤 변경 사항이 있었는지 구체적으로 설명 -->
- 


</br>


## 🎯 관련 이슈
<!-- 연결된 이슈가 있다면 아래에 작성 -->
-  cloese #25 

</br>


## 📚 참고 자료 (선택)
<!-- 참고한 외부 문서, 링크가 있다면 작성 -->
- https://www.notion.so/id-292819b5e8c680d0b429f373a5521219